### PR TITLE
fix : 다른 유저의 url로 들어가도 접근을 막지않는 현상 해결과 클래스 분류 및 비밀번호 수정시 유효성검사실시

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -70,7 +70,8 @@ class LoginSerializer(TokenObtainPairSerializer):
 
     def validate(self, attrs):
 
-        user = get_object_or_404(User, email=attrs['email'])    # 사용자의 정보를 찾을 수 없을 때 404 에러 뱉어냄
+        # 사용자의 정보를 찾을 수 없을 때 404 에러 뱉어냄
+        user = get_object_or_404(User, email=attrs['email'])
 
         # 전달받은 데이터와 사용자의 데이터의 이메일/비밀번호를 비교해 검증하고, 커스텀한 에러 메세지 보내기
         if user.is_active == False:
@@ -78,7 +79,7 @@ class LoginSerializer(TokenObtainPairSerializer):
         elif attrs['email'] != user.email:
             raise AuthenticationFailed("로그인에 실패했습니다. 로그인 정보를 확인하세요.") # 이메일 틀렸을 때
         elif check_password(attrs['password'], user.password) == False:
-            raise AuthenticationFailed("로그인에 실패했습니다. 로그인 정보를 확인하세요.") # 비밀번호 틀렸을 때
+            raise AuthenticationFailed("로그인에 실패했습니다. 로그인 정보를 확인하세요.")  # 비밀번호 틀렸을 때
         data = super().validate(attrs)
         return data
 

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -133,10 +133,25 @@ class ProfileUpdateSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ['email', 'nickname', 'password', 'user_img']
+        
+    # 비밀번호 유효성검사입니다.
+    def validate_password(self, value):
+        try:
+            validate_password(value)
+        except ValidationError as e:
+            raise serializers.ValidationError(e.messages)
+        return value    
+    
 
     def update(self, instance, validated_data):
         """회원 수정을 위한 메서드입니다."""
         password = validated_data.pop("password", None)
+        
+        # 비밀번호 유효성 검사
+        if password:
+            self.validate_password(password)
+        
+        
         user = super().update(instance, validated_data)
         if password:
             user.set_password(password)
@@ -148,4 +163,4 @@ class UserDataSerializer(serializers.ModelSerializer):
     """ 레시피 정보에서 유저정보 확인용 데이터입니다. """
     class Meta:
         model = User
-        fields = ("email", "user_img", "nickname", "following")
+        fields = ("email", "user_img", "nickname", "following","user_id")

--- a/users/urls.py
+++ b/users/urls.py
@@ -7,7 +7,7 @@ urlpatterns = [
     path('nickname-confirm/', views.DuplicateNicknameConfirmView.as_view(), name='duplicate_cnickname_onfirm_view'),
     path('verify-email/<str:uidb64>/<str:token>/', views.EmailVerificationView.as_view(), name='verify_email_view'),
     path('login/', views.LoginView.as_view(), name='login_view'),
-    path('api/signout/<int:user_id>/', views.UserDetailView.as_view(), name='signout_view'), # 회원탈퇴 url
+    path('api/signout/<int:user_id>/', views.UserUpdateView.as_view(), name='signout_view'), # 회원탈퇴 url
     path('<int:user_id>/',views.UserDetailView.as_view(), name='myprfile_view'), # 마이페이지 및 프로필 url
-    path('update/<int:user_id>/', views.UserDetailView.as_view(), name='update_view') # 회원정보수정 url
+    path('update/<int:user_id>/', views.UserUpdateView.as_view(), name='update_view') # 회원정보수정 url
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -105,7 +105,7 @@ class LoginView(TokenObtainPairView):
     serializer_class = LoginSerializer
 
 
-# 사용자 정보 및 회원정보 수정
+# 사용자 정보 확인
 class UserDetailView(APIView):
     """
     사용자의 정보를 get요청으로 받아야합니다.
@@ -115,16 +115,20 @@ class UserDetailView(APIView):
         user = get_object_or_404(User, pk=user_id)
         serializer = UserInfoSerializer(user)
         return Response(serializer.data, status=status.HTTP_200_OK)
+    
+
+# 사용자 정보 수정 및 삭제
+class UserUpdateView(APIView):
 
     """
     로그인한 사람의 정보를 put요청으로 수정해야합니다.
     """
-
+    permission_classes = [IsAuthenticated]
     def put(self, request, user_id, format=None):
         if not request.user.is_authenticated or request.user.id != user_id:
-            Response({"detail": "권한이 없습니다."}, status=status.HTTP_403_FORBIDDEN)
-        serializer = ProfileUpdateSerializer(
-            request.user, data=request.data, partial=True)
+            return Response({"detail": "권한이 없습니다."}, status=status.HTTP_403_FORBIDDEN)
+            
+        serializer = ProfileUpdateSerializer(request.user, data=request.data, partial=True)
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
1. 회원정보 수정시 url을 변경해도 회원정보 수정이 가능한 현상 해결
2. 추가로 회원정보 수정과 정보요청이 하나의 클래스로 분류되어서 클래스 분류
3. 회원정보에서 비밀번호 변경시 유효성 검사를 하지않았던것을 하도록 추가
4. UserDataSerializer에 추가로 user_id 건내도록 추가