### PR TITLE
fix: 프론트 도메인 주소 환경변수에서 관리

### DIFF
--- a/teulang/settings.py
+++ b/teulang/settings.py
@@ -166,7 +166,7 @@ EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD')
 EMAIL_USE_TLS = True
 DEFAULT_FROM_EMAIL = EMAIL_HOST_USER # 응답 메일 관련 설정
 DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
-URL_FRONT = "http://localhost:3000" # 'https://teulang.net'
+URL_FRONT = env('URL_FRONT') # 'https://teulang.net'
 
 DOMAIN_ADDRESS = env('DOMAIN_ADDRESS')
 


### PR DESCRIPTION
소셜로그인 로직 수정으로 url front 사용하게 돼서 배포를 위해 환경변수 관리 필요성을 느껴 수정.